### PR TITLE
fix: TOOLS-2962 Handle boolean values on JSON bin value

### DIFF
--- a/src/main/asql_print.c
+++ b/src/main/asql_print.c
@@ -208,7 +208,7 @@ print_dml_help()
 	fprintf(stdout, "      Examples:\n");
 	fprintf(stdout, "      \n");
 	fprintf(stdout, "          INSERT INTO test.demo (PK, foo, bar, baz) VALUES ('key1', 123, 'abc', true)\n");
-	fprintf(stdout, "          INSERT INTO test.demo (PK, foo, bar, baz) VALUES ('key1', CAST('123' AS INT), JSON('{\"a\": 1.2, \"b\": [1, 2, 3]}'), BOOL(1))\n");
+	fprintf(stdout, "          INSERT INTO test.demo (PK, foo, bar, baz) VALUES ('key1', CAST('123' AS INT), JSON('{\"a\": 1.2, \"b\": [1, 2, 3], \"c\": true}'), BOOL(1))\n");
 	fprintf(stdout, "          INSERT INTO test.demo (PK, foo, bar) VALUES ('key1', LIST('[1, 2, 3]'), MAP('{\"a\": 1, \"b\": 2}'), CAST(0 as BOOL))\n");
 	fprintf(stdout, "          INSERT INTO test.demo (PK, gj) VALUES ('key1', GEOJSON('{\"type\": \"Point\", \"coordinates\": [123.4, -56.7]}'))\n");
 	fprintf(stdout, "          DELETE FROM test.demo WHERE PK = 'key1'\n");

--- a/src/main/json.c
+++ b/src/main/json.c
@@ -347,6 +347,8 @@ json_to_val(json_t* j)
 		return (as_val*)json_number_to_integer(j);
 	if (json_is_real(j))
 		return (as_val*)as_double_new((double)json_real_value(j));
+	if (json_is_boolean(j))
+		return (as_val*)as_boolean_new(json_boolean_value(j));
 	return (as_val*) NULL; //&as_nil;
 }
 


### PR DESCRIPTION
Verified:

# Test 1:
```
aql> INSERT INTO test.myset (PK, foo, bar) VALUES ('key1',true,JSON('{"a":false,"b": [1, 2, 3]}'))
OK, 1 record affected.
```

```
aql> select * from test.myset
+--------+------+-----------------------------------+
| PK     | foo  | bar                               |
+--------+------+-----------------------------------+
| "key1" | true | MAP('{"a":false, "b":[1, 2, 3]}') |
+--------+------+-----------------------------------+
1 row in set (0.009 secs)

OK
```

# Test 2:
```
aql> INSERT INTO test.myset (PK, foo, bar) VALUES ('key1',true,JSON('{"a":true,"b": [1, 2, 3]}'))
OK, 1 record affected.
```

```
aql> select * from test.myset
+--------+------+----------------------------------+
| PK     | foo  | bar                              |
+--------+------+----------------------------------+
| "key1" | true | MAP('{"a":true, "b":[1, 2, 3]}') |
+--------+------+----------------------------------+
1 row in set (0.012 secs)

OK
```

