### PR TITLE
fix: update mac artifact workflow to use array syntax for event types

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -2,7 +2,7 @@ name: Mac Artifact
 
 on:
   repository_dispatch:
-    types: mac-build
+    types: [mac-build]
   push:
     branches: [actionsHub, main, "*-bugfix"]
   pull_request:


### PR DESCRIPTION
Fix Github Action mac-artifact Syntax