### PR TITLE
docs: TOOLS-3096 Update README with deprecation notice for aql

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Aerospike Quick Look
 
 A SQL-like command-line interface (aql) used to browse data stored in Aerospike database.
-The aql tool is deprecated and scheduled to be removed from the Aerospike tools package.  No new features will be added to aql. Data browsing alternatives include the Aerospike JDBC driver.
+The aql tool is deprecated and scheduled to be removed from the Aerospike tools package.  No new features will be added to aql. Data browsing alternatives include the [Aerospike JDBC driver](https://github.com/aerospike/aerospike-jdbc).
 
 
 ## Cloning the repo

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aerospike Quick Look
+# Aerospike Quick Look (Deprecated)
 
 A SQL-like command-line interface (aql) used to browse data stored in Aerospike database.
 The aql tool is deprecated and scheduled to be removed from the Aerospike tools package.  No new features will be added to aql. Data browsing alternatives include the [Aerospike JDBC driver](https://github.com/aerospike/aerospike-jdbc).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# AQL
+# Aerospike Quick Look
 
-A SQL-like command-line interface to the Aerospike database.
+A SQL-like command-line interface (aql) used to browse data stored in Aerospike database.
+The aql tool is deprecated and scheduled to be removed from the Aerospike tools package.  No new features will be added to aql. Data browsing alternatives include the Aerospike JDBC driver.
+
 
 ## Cloning the repo
 ```


### PR DESCRIPTION
Added a deprecation notice to the README, clarifying that the aql tool is scheduled for removal and suggesting alternatives such as the Aerospike JDBC driver.