### PR TITLE
fix: TOOLS-3017 compiler warnings, type casting, unused functions, and null pointer assignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ xcuserdata
 *.xccheckout
 *.swp
 *~.nib
+.cache

--- a/src/main/asql_explain.c
+++ b/src/main/asql_explain.c
@@ -107,9 +107,9 @@ asql_key_select_explain(asql_config* c, pk_config* p, as_key* key,
 		}
 
 		as_partition *asp = &pptable->partitions[partition_id];
-		master = (as_node *)as_load_ptr(&asp->nodes[0]);
-		prole_1 = (as_node *)as_load_ptr(&asp->nodes[1]);
-		prole_2 = (as_node *)as_load_ptr(&asp->nodes[2]);
+		master = (as_node *)as_load_ptr((void* const*)&asp->nodes[0]);
+		prole_1 = (as_node *)as_load_ptr((void* const*)&asp->nodes[1]);
+		prole_2 = (as_node *)as_load_ptr((void* const*)&asp->nodes[2]);
 	}
 
 	if (master) {

--- a/src/main/asql_info.c
+++ b/src/main/asql_info.c
@@ -430,7 +430,7 @@ bins_build_res_check(void* udata, const as_node* node, const char* req, char* re
 	for (int idx = 0; idx < parsed_resp->size; idx++) {
 		as_hashmap* map = as_vector_get_ptr(parsed_resp, idx);
 		as_string* build_key = as_string_new("build", false);
-		as_string* val = as_string_fromval(as_hashmap_get(map, build_key));
+		as_string* val = as_string_fromval(as_hashmap_get(map, (const as_val*)build_key));
 		as_string* bin_rm_build = as_string_new(strdup("7.0.0.0"), true);
 
 		if (build_gte(val, bin_rm_build)) {

--- a/src/main/asql_parser.c
+++ b/src/main/asql_parser.c
@@ -51,8 +51,6 @@ void strncpy_and_strip_quotes(char* to, const char* from, size_t size);
 static bool is_quoted_literal(char* s);
 static bool check_illegal_characters(char* s);
 
-static bool lut_is_valid(char* s, uint64_t lut);
-static bool parse_lut(char* s, uint64_t* lut);
 static bool parse_name(char* s, asql_name* name, bool allow_empty);
 static int parse_expression(tokenizer* tknzr, asql_value* value);
 static int parse_value(char* s, asql_value* value);

--- a/src/main/sql-lexer.l
+++ b/src/main/sql-lexer.l
@@ -73,6 +73,7 @@ static bool gError = false;
 %START SQUOTE DQUOTE
 
 %option noyywrap
+%option noinput
 
 %%
 
@@ -202,7 +203,7 @@ int as_sql_lexer(char *input, char **token, bool peek)
 
    if (done) {
       if (token) {
-        *token = '\0';
+        *token = NULL;
       }
       return ERROR;
    }
@@ -223,13 +224,13 @@ int as_sql_lexer(char *input, char **token, bool peek)
       rv = OK;
    } else if (gError) {
       if (token) {
-         *token = '\0';
+         *token = NULL;
       }
       done = true;
       rv = ERROR;
    } else {
       if (token) {
-         *token = '\0';
+         *token = NULL;
       }
       done = true;
       rv = DONE;


### PR DESCRIPTION
### Summary
This PR addresses multiple compiler warnings across the codebase by fixing type casting issues, removing unused function declarations, and correcting null pointer assignments.

With Debian 13, gcc (Debian 14.2.0-19) 14.2.0 , these warnings error out.  
Check http://build.browser.qe.aerospike.com/citrusleaf/aerospike-tools/12.0.0-rc1-3-gc633e3d/build/debian-13/default/build.log

Success after these changes http://build.browser.qe.aerospike.com/citrusleaf/aerospike-tools/12.0.0-rc1-4-g16d7f45/build/arm-debian-13/default/build.log

### Changes Made

#### 1. Fix Type Casting Warnings in `src/main/asql_explain.c`
- **Issue**: Incompatible pointer types when calling `as_load_ptr()` with `struct as_node_s**` instead of expected `void* const*`
- **Fix**: Added proper type casting `(void* const*)` to function calls
- **Lines**: 109-111
```c
// Before
master = (as_node *)as_load_ptr(&asp->nodes[0]);
prole_1 = (as_node *)as_load_ptr(&asp->nodes[1]);
prole_2 = (as_node *)as_load_ptr(&asp->nodes[2]);

// After  
master = (as_node *)as_load_ptr((void* const*)&asp->nodes[0]);
prole_1 = (as_node *)as_load_ptr((void* const*)&asp->nodes[1]);
prole_2 = (as_node *)as_load_ptr((void* const*)&asp->nodes[2]);
```

#### 2. Fix Type Casting Warning in `src/main/asql_info.c`
- **Issue**: Incompatible pointer types when calling `as_hashmap_get()` with `as_string*` instead of expected `const as_val*`
- **Fix**: Added proper type casting `(const as_val*)` to function call
- **Line**: 432
```c
// Before
as_string* val = as_string_fromval(as_hashmap_get(map, build_key));

// After
as_string* val = as_string_fromval(as_hashmap_get(map, (const as_val*)build_key));
```

#### 3. Remove Unused Function Declarations in `src/main/asql_parser.c`
- **Issue**: Unused function declarations causing compiler warnings
- **Fix**: Commented out unused function declarations
- **Lines**: 53-54
```c
// Before
static bool lut_is_valid(char* s, uint64_t lut);
static bool parse_lut(char* s, uint64_t* lut);

// After
// static bool lut_is_valid(char* s, uint64_t lut);
// static bool parse_lut(char* s, uint64_t* lut);
```

#### 4. Fix Null Pointer Assignment Warnings in `src/main/sql-lexer.l`
- **Issue**: Assigning character literal `'\0'` to `char*` pointer causing null pointer conversion warnings
- **Fix**: Changed to proper `NULL` assignments and added flex option to suppress unused function warning
- **Lines**: 206, 227, 233, and added `%option noinput`
```c
// Before
*token = '\0';

// After
*token = NULL;
```

### Testing
- All changes maintain existing functionality
- Compiler warnings are eliminated
- Type safety is improved
- No behavioral changes to the API

### Impact
- **Positive**: Cleaner compilation without warnings
- **Positive**: Better type safety and code clarity
- **Neutral**: No functional changes to the codebase

### Files Modified
- `src/main/asql_explain.c`
- `src/main/asql_info.c` 
- `src/main/asql_parser.c`
- `src/main/sql-lexer.l`