### PR TITLE
fix: suppress debconf frontend warnings on Ubuntu 26.04

### DIFF
--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -93,8 +93,11 @@ function install_deps_ubuntu26.04() {
 	rm -rf /var/lib/apt/lists/*
 	apt-get clean
 	apt-get update -o Acquire::Retries=5
+	# libterm-readline-perl-perl: provides Term::ReadLine so debconf can use
+	# the Readline frontend instead of printing frontend-init warnings.
 	apt-get install -y --no-install-recommends $BUILD_DEPS_UBUNTU ruby-rubygems make rpm git curl binutils \
-		python3 python3-pip rsync libssl-dev lzma liblzma-dev libffi-dev build-essential ruby-dev
+		python3 python3-pip rsync libssl-dev lzma liblzma-dev libffi-dev build-essential ruby-dev \
+		libterm-readline-perl-perl
 	gem install fpm -v "$FPM_VERSION"
 	apt-get clean
 	rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -47,11 +47,12 @@ jobs:
           egress-policy: audit
 
       - name: Install prereqs
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           set -euo pipefail
           case "${{ matrix.distro }}" in
             ubuntu*|debian*)
-              export DEBIAN_FRONTEND=noninteractive
               apt-get update
               apt-get install -y --no-install-recommends git ca-certificates
               ;;


### PR DESCRIPTION
## Problem

When installing the Ubuntu 26.04 `.deb` package in a minimal container, `apt` / `dpkg` emits noisy debconf warnings:

```
debconf: unable to initialize frontend: Dialog
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm ...)
debconf: falling back to frontend: Teletype
```

The install succeeds (Teletype fallback works), but the warnings are confusing and clutter CI logs.

## Root cause

Two gaps in the Ubuntu 26.04 setup:

1. **Missing `Term::ReadLine` Perl module** — the minimal `ubuntu:resolute` image ships without `libterm-readline-perl-perl`, so debconf cannot use its Readline frontend.
2. **`DEBIAN_FRONTEND` scope** — in `build-check.yml` the variable was set via `export` inside the shell `case` branch, which means it was not visible to child processes spawned outside that branch (e.g. `dpkg` called by apt).

## Changes

| File | Change |
|---|---|
| `.github/bin/install_deps.sh` | Add `libterm-readline-perl-perl` to `install_deps_ubuntu26.04()` |
| `.github/workflows/build-check.yml` | Move `DEBIAN_FRONTEND=noninteractive` from inline `export` to the step `env:` block |

🤖 Generated with [Claude Code](https://claude.com/claude-code)