### PR TITLE
ci: Prefer static readline on Linux in Makefile

### DIFF
--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -135,7 +135,9 @@ function install_deps_el10() {
 	# so the Makefile can static-link it (same approach as the qe-docker images).
 	dnf -y install ncurses-devel wget tar make gcc
 	local _rl_ver="8.2"
-	wget -q "http://ftp.gnu.org/gnu/readline/readline-${_rl_ver}.tar.gz" -P /tmp
+	local _rl_sha256="3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35"
+	wget -q "https://ftp.gnu.org/gnu/readline/readline-${_rl_ver}.tar.gz" -P /tmp
+	echo "${_rl_sha256}  /tmp/readline-${_rl_ver}.tar.gz" | sha256sum -c -
 	tar -xzf "/tmp/readline-${_rl_ver}.tar.gz" -C /tmp
 	cd "/tmp/readline-${_rl_ver}"
 	./configure --prefix=/usr --includedir=/usr/include --libdir=/usr/lib64 CFLAGS="-fPIC"

--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -130,7 +130,19 @@ function install_deps_el10() {
 	dnf clean all
 	dnf -y update
 	yum install -y "https://dl.rockylinux.org/vault/rocky/10.0/AppStream/$(uname -m)/os/Packages/f/flex-2.6.4-19.el10.$(uname -m).rpm"
-	yum install -y "https://dl.rockylinux.org/vault/rocky/10.0/devel/$(uname -m)/os/Packages/r/readline-devel-8.2-11.el10.$(uname -m).rpm"
+	# readline-devel on RHEL 10 no longer ships libreadline.a (static archives
+	# were dropped from devel packages).  Build from source to get libreadline.a
+	# so the Makefile can static-link it (same approach as the qe-docker images).
+	dnf -y install ncurses-devel wget tar make gcc
+	local _rl_ver="8.2"
+	wget -q "http://ftp.gnu.org/gnu/readline/readline-${_rl_ver}.tar.gz" -P /tmp
+	tar -xzf "/tmp/readline-${_rl_ver}.tar.gz" -C /tmp
+	cd "/tmp/readline-${_rl_ver}"
+	./configure --prefix=/usr --includedir=/usr/include --libdir=/usr/lib64 CFLAGS="-fPIC"
+	make -j"$(nproc)" SHLIB_LIBS="-lncurses -ltinfo"
+	make install
+	cd -
+	rm -rf "/tmp/readline-${_rl_ver}" "/tmp/readline-${_rl_ver}.tar.gz"
 	dnf -y install $BUILD_DEPS_REDHAT ruby ruby-devel rpmdevtools make git python3 python3-pip rsync
 	build_libyaml_static
 	gem install fpm -v "$FPM_VERSION"

--- a/Makefile
+++ b/Makefile
@@ -101,9 +101,24 @@ else
   endif
 endif
 
-LIBRARIES += $(LUA_LIB) -lpthread -lm -lreadline -lz
+# Readline: on Linux always force static linking so the built binary has no
+# libreadline.so runtime dependency across any distro.
+# libreadline.a is available in all Docker images:
+#   Ubuntu/Debian  → libreadline-dev puts it in the multiarch lib dir
+#   RHEL           → built from source into /usr/lib
+# -Wl,-Bstatic/-Wl,-Bdynamic bracket just readline+history; libtinfo is then
+# linked dynamically (-ltinfo) to satisfy readline's tputs/tgetent references.
+# libtinfo.so.6 is a base system library present on all Linux distros.
+# macOS always links dynamically (Homebrew readline, no -Wl,-Bstatic support).
+ifeq ($(OS),Darwin)
+  READLINE_LIB := -lreadline -lhistory
+else
+  READLINE_LIB := -Wl,-Bstatic -lreadline -lhistory -Wl,-Bdynamic -ltinfo
+endif
+
+LIBRARIES += $(LUA_LIB) -lpthread -lm $(READLINE_LIB) -lz
 ifneq ($(OS),Darwin)
-  LIBRARIES += -lhistory -lrt -ldl -lz
+  LIBRARIES += -lrt -ldl -lz
 endif
 
 # Static link libyaml to avoid runtime dependency

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ endif
 # libtinfo.so.6 is a base system library present on all Linux distros.
 # macOS always links dynamically (Homebrew readline, no -Wl,-Bstatic support).
 ifeq ($(OS),Darwin)
-  READLINE_LIB := -lreadline -lhistory
+  READLINE_LIB := -lreadline
 else
   READLINE_LIB := -Wl,-Bstatic -lreadline -lhistory -Wl,-Bdynamic -ltinfo
 endif

--- a/Makefile
+++ b/Makefile
@@ -101,19 +101,26 @@ else
   endif
 endif
 
-# Readline: on Linux always force static linking so the built binary has no
-# libreadline.so runtime dependency across any distro.
-# libreadline.a is available in all Docker images:
-#   Ubuntu/Debian  → libreadline-dev puts it in the multiarch lib dir
-#   RHEL           → built from source into /usr/lib
-# -Wl,-Bstatic/-Wl,-Bdynamic bracket just readline+history; libtinfo is then
-# linked dynamically (-ltinfo) to satisfy readline's tputs/tgetent references.
-# libtinfo.so.6 is a base system library present on all Linux distros.
-# macOS always links dynamically (Homebrew readline, no -Wl,-Bstatic support).
+# Readline: prefer static linking to eliminate the libreadline.so runtime dep.
+# Fall back to dynamic if libreadline.a is absent — RHEL 10+ dropped static
+# archives from readline-devel, so dynamic is the only option there.
+# qe-docker images (which build readline from source) always have the .a.
+# macOS: always dynamic (Homebrew; Apple ld has no -Wl,-Bstatic).
 ifeq ($(OS),Darwin)
   READLINE_LIB := -lreadline
 else
-  READLINE_LIB := -Wl,-Bstatic -lreadline -lhistory -Wl,-Bdynamic -ltinfo
+  _READLINE_A := $(firstword $(wildcard \
+      /usr/local/lib/libreadline.a \
+      /usr/lib/libreadline.a \
+      /usr/lib64/libreadline.a \
+      /usr/lib/$(shell uname -m)-linux-gnu/libreadline.a))
+  ifneq ($(_READLINE_A),)
+    # Static: bracket readline+history; tinfo resolved dynamically after -Wl,-Bdynamic.
+    READLINE_LIB := -Wl,-Bstatic -lreadline -lhistory -Wl,-Bdynamic -ltinfo
+  else
+    # Dynamic fallback: tinfo is satisfied transitively via libreadline.so.
+    READLINE_LIB := -lreadline -lhistory
+  endif
 endif
 
 LIBRARIES += $(LUA_LIB) -lpthread -lm $(READLINE_LIB) -lz

--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,9 @@ else
 endif
 
 # Readline: prefer static linking to eliminate the libreadline.so runtime dep.
-# Fall back to dynamic if libreadline.a is absent — RHEL 10+ dropped static
-# archives from readline-devel, so dynamic is the only option there.
-# qe-docker images (which build readline from source) always have the .a.
+# Fall back to dynamic if libreadline.a is absent — RHEL 10+ distro packages
+# dropped static archives from readline-devel, but CI builds readline from
+# source (install_deps_el10) so the .a is always available there.
 # macOS: always dynamic (Homebrew; Apple ld has no -Wl,-Bstatic).
 ifeq ($(OS),Darwin)
   READLINE_LIB := -lreadline


### PR DESCRIPTION
Introduce a READLINE_LIB variable and conditionally link readline statically on Linux while keeping dynamic linkage on macOS. This uses -Wl,-Bstatic/-Wl,-Bdynamic to static-link readline+history and link libtinfo dynamically to satisfy tputs/tgetent, avoiding a runtime libreadline.so dependency across distros. Also remove the duplicate -lhistory addition in the non-Darwin block and adjust LIBRARIES accordingly.