### PR TITLE
ci: name release bundle with direct VERSION on real releases

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -718,7 +718,10 @@ jobs:
       jf-bundle-name: "aerospike-aql"
       oidc-provider-name: database-gh-aerospike
       oidc-audience: database-gh-aerospike
-      version: ${{ needs.get-version.outputs.BUNDLE_VERSION }}
+      # Real release (main, not skip_tagging) publishes the release bundle under
+      # the direct VERSION (e.g. 9.2.7); feature-style / non-release publishes keep
+      # the branch-prefixed BUNDLE_VERSION (e.g. mybranch-9.2.7-mybranch.<sha>).
+      version: ${{ github.ref == 'refs/heads/main' && inputs.skip_tagging != true && needs.get-version.outputs.VERSION || needs.get-version.outputs.BUNDLE_VERSION }}
       gh-workflows-ref: v3.6.0
       dry-run: false
 


### PR DESCRIPTION
Aligns this repo's release-bundle naming with aerospike-admin.

**Before:** `create-release-bundle` always used `BUNDLE_VERSION` (`<branch>-<version>`), so even a real release produced e.g. `main-2.2.7`.

**After:** on a real release (default branch, `skip_tagging` false) the release bundle is named with the direct `VERSION` (e.g. `2.2.7`). Feature-style / non-release publishes still use the branch-prefixed `BUNDLE_VERSION` to stay collision-safe.

Single-line change to the `create-release-bundle` version input; `BUNDLE_VERSION` is retained for the non-release path.