### PR TITLE
ci: publish release bundles under direct VERSION (uniform across tools)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -107,7 +107,6 @@ jobs:
       contents: read
     outputs:
       VERSION: ${{ steps.compute.outputs.version }}
-      BUNDLE_VERSION: ${{ steps.compute.outputs.bundle_version }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
@@ -136,12 +135,8 @@ jobs:
               VERSION="${BASE}-${BRANCH_SLUG}.${SHORT_SHA}"
             fi
           fi
-          BRANCH_PREFIX="${GITHUB_REF_NAME//\//-}"
-          BUNDLE_VERSION="${BRANCH_PREFIX}-${VERSION}"
           echo "VERSION: ${VERSION}"
-          echo "BUNDLE_VERSION: ${BUNDLE_VERSION}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "bundle_version=${BUNDLE_VERSION}" >> "$GITHUB_OUTPUT"
 
   build-artifacts:
     needs: get-version
@@ -723,10 +718,7 @@ jobs:
       jf-bundle-name: "aerospike-aql"
       oidc-provider-name: database-gh-aerospike
       oidc-audience: database-gh-aerospike
-      # Real release (main, not skip_tagging) publishes the release bundle under
-      # the direct VERSION (e.g. 9.2.7); feature-style / non-release publishes keep
-      # the branch-prefixed BUNDLE_VERSION (e.g. mybranch-9.2.7-mybranch.<sha>).
-      version: ${{ github.ref == 'refs/heads/main' && inputs.skip_tagging != true && needs.get-version.outputs.VERSION || needs.get-version.outputs.BUNDLE_VERSION }}
+      version: ${{ needs.get-version.outputs.VERSION }}
       gh-workflows-ref: v3.6.0
       dry-run: false
 


### PR DESCRIPTION
## What

Drop the branch-prefixed `BUNDLE_VERSION` and publish every JFrog release bundle under the SemVer `VERSION` directly, matching `aerospike-admin` (asadm). This makes the release-bundle version scheme uniform across all five tools.

## Why

Non-release / feature-branch publishes were doubling the branch name, e.g. `main-9.2.7-main.<sha>`, because `VERSION` already embeds `<branch>.<sha>` as a SemVer pre-release tag and `BUNDLE_VERSION` prepended `<branch>-` again. The SHA already disambiguates, so the prefix was redundant.

## Resulting version pattern (now identical for all 5 tools)

- Real release (main, not skip_tagging): `9.2.7`
- Non-release / feature / skip_tagging: `9.2.7-main.<sha>` (branch appears once)

## Note

This branch also carries earlier related CI commit(s) that were already on it. Draft for review.