### PR TITLE
fix(pkg): make packages self-contained for airgapped installs

### DIFF
--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+function assert_dynamic_deps() {
+	local allowed="libc.so.6 libm.so.6 libpthread.so.0 libdl.so.2 librt.so.1
+		libgcc_s.so.1 libz.so.1 libtinfo.so.6 ld-linux-x86-64.so.2 ld-linux-aarch64.so.1"
+	if [ "$ENV_DISTRO" = "el8" ] || [ "$ENV_DISTRO" = "debian11" ]; then
+		allowed+=" libssl.so.1.1 libcrypto.so.1.1"
+	else
+		allowed+=" libssl.so.3 libcrypto.so.3"
+	fi
+
+	local lib fail=0
+	local bin="target/$(uname -s)-$(uname -m)/bin/aql"
+	local needed
+	needed=$(readelf -d "$bin" | awk '/\(NEEDED\)/ { gsub(/[][]/, "", $NF); print $NF }')
+	echo "aql DT_NEEDED:" $needed
+	for lib in $needed; do
+		if ! printf '%s\n' $allowed | grep -qxF "$lib"; then
+			echo "aql has unexpected dynamic dependency $lib; link it statically or add it to the allowlist and the package depends" >&2
+			fail=1
+		fi
+	done
+	return $fail
+}
+
 function build_packages() {
 	if [ "${ENV_DISTRO:-}" = "" ]; then
 		echo "ENV_DISTRO is not set" >&2
@@ -17,10 +40,7 @@ function build_packages() {
 	make clean
 	make
 
-	if ldd "target/$(uname -s)-$(uname -m)/bin/aql" | grep readline; then
-		echo "aql dynamically links readline; packages must ship a static-readline binary" >&2
-		return 1
-	fi
+	assert_dynamic_deps
 
 	echo "build_package.sh version: ${VERSION}"
 

--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -17,6 +17,11 @@ function build_packages() {
 	make clean
 	make
 
+	if ldd "target/$(uname -s)-$(uname -m)/bin/aql" | grep readline; then
+		echo "aql dynamically links readline; packages must ship a static-readline binary" >&2
+		return 1
+	fi
+
 	echo "build_package.sh version: ${VERSION}"
 
 	# package

--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -4,9 +4,24 @@ set -xeuo pipefail
 export FPM_VERSION="1.17.0"
 
 BUILD_DEPS_REDHAT="readline which autoconf libtool openssl-devel zlib-devel"
-BUILD_DEPS_AMAZON="readline which autoconf libtool readline-devel flex openssl-devel zlib-devel"
+BUILD_DEPS_AMAZON="readline which autoconf libtool flex openssl-devel zlib-devel"
 BUILD_DEPS_UBUNTU="libreadline-dev flex autoconf automake libtool libyaml-dev zlib1g-dev"
 BUILD_DEPS_DEBIAN="libreadline-dev flex autoconf automake libtool libyaml-dev zlib1g-dev"
+
+function build_readline_static() {
+	local RL_VERSION="8.2"
+	local RL_SHA256="3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35"
+	pushd /tmp
+	curl -sL "https://ftp.gnu.org/gnu/readline/readline-${RL_VERSION}.tar.gz" -o "readline-${RL_VERSION}.tar.gz"
+	echo "${RL_SHA256}  readline-${RL_VERSION}.tar.gz" | sha256sum -c -
+	tar -xzf "readline-${RL_VERSION}.tar.gz"
+	cd "readline-${RL_VERSION}"
+	./configure --prefix=/usr --includedir=/usr/include --libdir=/usr/lib64 CFLAGS="-fPIC"
+	make -j"$(nproc)" SHLIB_LIBS="-lncurses -ltinfo"
+	make install
+	popd
+	rm -rf "/tmp/readline-${RL_VERSION}" "/tmp/readline-${RL_VERSION}.tar.gz"
+}
 
 function build_libyaml_static() {
 	local LIBYAML_VERSION="0.2.5"
@@ -108,8 +123,8 @@ function install_deps_el8() {
 	dnf -y update
 	dnf module enable -y ruby:2.7
 	yum install -y "https://download.rockylinux.org/pub/rocky/8.10/AppStream/$(uname -m)/os/Packages/f/flex-2.6.1-9.el8.$(uname -m).rpm"
-	yum install -y "https://download.rockylinux.org/pub/rocky/8.10/Devel/$(uname -m)/os/Packages/r/readline-devel-7.0-10.el8.$(uname -m).rpm"
-	dnf -y install $BUILD_DEPS_REDHAT gcc-c++ ruby ruby-devel rpm-build make git python3 python3-pip rsync wget
+	dnf -y install $BUILD_DEPS_REDHAT gcc-c++ ruby ruby-devel rpm-build make git python3 python3-pip rsync wget ncurses-devel
+	build_readline_static
 	build_libyaml_static
 	gem install --no-document fpm -v "$FPM_VERSION"
 	dnf clean all
@@ -119,8 +134,8 @@ function install_deps_el9() {
 	dnf clean all
 	dnf -y update
 	yum install -y "https://dl.rockylinux.org/vault/rocky/9.6/AppStream/$(uname -m)/os/Packages/f/flex-2.6.4-9.el9.$(uname -m).rpm"
-	yum install -y "https://dl.rockylinux.org/vault/rocky/9.6/devel/$(uname -m)/os/Packages/r/readline-devel-8.1-4.el9.$(uname -m).rpm"
-	dnf -y install $BUILD_DEPS_REDHAT ruby ruby-devel rpmdevtools make git python3 python3-pip rsync
+	dnf -y install $BUILD_DEPS_REDHAT gcc ruby ruby-devel rpmdevtools make git python3 python3-pip rsync ncurses-devel
+	build_readline_static
 	build_libyaml_static
 	gem install fpm -v "$FPM_VERSION"
 	dnf clean all
@@ -130,22 +145,8 @@ function install_deps_el10() {
 	dnf clean all
 	dnf -y update
 	yum install -y "https://dl.rockylinux.org/vault/rocky/10.0/AppStream/$(uname -m)/os/Packages/f/flex-2.6.4-19.el10.$(uname -m).rpm"
-	# readline-devel on RHEL 10 no longer ships libreadline.a (static archives
-	# were dropped from devel packages).  Build from source to get libreadline.a
-	# so the Makefile can static-link it (same approach as the qe-docker images).
-	dnf -y install ncurses-devel wget tar make gcc
-	local _rl_ver="8.2"
-	local _rl_sha256="3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35"
-	wget -q "https://ftp.gnu.org/gnu/readline/readline-${_rl_ver}.tar.gz" -P /tmp
-	echo "${_rl_sha256}  /tmp/readline-${_rl_ver}.tar.gz" | sha256sum -c -
-	tar -xzf "/tmp/readline-${_rl_ver}.tar.gz" -C /tmp
-	cd "/tmp/readline-${_rl_ver}"
-	./configure --prefix=/usr --includedir=/usr/include --libdir=/usr/lib64 CFLAGS="-fPIC"
-	make -j"$(nproc)" SHLIB_LIBS="-lncurses -ltinfo"
-	make install
-	cd -
-	rm -rf "/tmp/readline-${_rl_ver}" "/tmp/readline-${_rl_ver}.tar.gz"
-	dnf -y install $BUILD_DEPS_REDHAT ruby ruby-devel rpmdevtools make git python3 python3-pip rsync
+	dnf -y install $BUILD_DEPS_REDHAT gcc ruby ruby-devel rpmdevtools make git python3 python3-pip rsync ncurses-devel tar
+	build_readline_static
 	build_libyaml_static
 	gem install fpm -v "$FPM_VERSION"
 	dnf clean all
@@ -154,7 +155,8 @@ function install_deps_el10() {
 function install_deps_amzn2023() {
 	dnf clean all
 	dnf -y update
-	dnf -y install $BUILD_DEPS_AMAZON ruby ruby-devel rpmdevtools make git python3 python3-pip rsync
+	dnf -y install $BUILD_DEPS_AMAZON gcc ruby ruby-devel rpmdevtools make git python3 python3-pip rsync ncurses-devel tar
+	build_readline_static
 	build_libyaml_static
 	gem install fpm -v "$FPM_VERSION"
 	dnf clean all

--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,12 @@ else
 endif
 
 # Readline: prefer static linking to eliminate the libreadline.so runtime dep.
-# Fall back to dynamic if libreadline.a is absent — RHEL 10+ distro packages
-# dropped static archives from readline-devel, but CI builds readline from
-# source (install_deps_el10) so the .a is always available there.
-# macOS: always dynamic (Homebrew; Apple ld has no -Wl,-Bstatic).
+# Fall back to dynamic if libreadline.a is absent. Debian/Ubuntu libreadline-dev
+# ships the .a; RHEL-family readline-devel does not, so CI builds readline from
+# source there (build_readline_static in install_deps.sh). build_package.sh
+# rejects binaries that link readline dynamically, keeping packages airgap-safe.
+# macOS: always dynamic; -lreadline resolves to the system libedit shim
+# (SDK libreadline.tbd -> libedit.tbd), present on every macOS.
 ifeq ($(OS),Darwin)
   READLINE_LIB := -lreadline
 else

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -56,6 +56,8 @@ rpm: prep
 		--name $(NAME) \
 		--version $(RPM_VERSION) \
 		--maintainer $(MAINTAINER) \
+		--depends "openssl-libs" \
+		--depends "ncurses-libs" \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \
 		--url $(URL) \

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -44,7 +44,6 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--depends "libreadline8 | libreadline8t64" \
 		--package $(TARGET_DIR)/$(NAME)_$(VERSION)_$(BUILD_DISTRO)_$(ARCH).deb
 
 .PHONY: rpm


### PR DESCRIPTION
## Problem

Installing the standalone `aerospike-aql` deb on an airgapped system fails with:

```
aerospike-aql : missing libreadline8
```

Since 9.2.7 (#72, TOOLS-3551) the Debian/Ubuntu builds statically link readline, but the deb still declared `--depends "libreadline8 | libreadline8t64"`. On connected systems apt silently installs the unneeded library; on airgapped systems dpkg fails on a dependency the binary no longer has.

Auditing the rest of the matrix surfaced a second gap: on el8/el9/amzn2023, `readline-devel` ships no `libreadline.a`, so those builds silently took the dynamic-readline fallback. fpm generates no automatic rpm Requires, so those rpms install anywhere but crash at startup on hosts without readline.

## Changes

- **pkg/Makefile**: drop the stale `libreadline8 | libreadline8t64` Depends from the deb target.
- **install_deps.sh**: extract the el10 readline source build into a shared `build_readline_static()` and use it for el8, el9, and amzn2023 too (drops the Rocky vault `readline-devel` downloads and `readline-devel` from `BUILD_DEPS_AMAZON`). All Linux packages now ship a statically linked readline.
- **build_package.sh**: fail the build if `aql` ends up dynamically linked against readline, so the fallback can't silently regress packaging again.
- **Makefile**: update the readline linkage comment to match.

## Per-distro state after this change

| Build env | readline linkage |
|---|---|
| debian 11/12/13, ubuntu 22.04/24.04/26.04 | static (`libreadline-dev` ships `.a`) |
| el8, el9, el10, amzn2023 | static (built from GNU source 8.2) |
| macOS | dynamic against the system libedit shim (`libreadline.tbd -> libedit.tbd`), present on every macOS |

## Verification

- Built the ubuntu24.04 deb and amzn2023 rpm in clean containers via `install_deps.sh` + `build_package.sh`.
- deb control has no Depends; installed with `dpkg -i` in a `--network none` ubuntu:24.04 container with no readline packages present; `aql --version` and `aql --help` work; `ldd` shows no readline.
- rpm Requires only `/bin/sh` + rpmlib; installed with `rpm -i` in a `--network none` amazonlinux:2023 container; runs fine; `ldd` shows no readline.
- The new ldd guard ran and passed in both builds.

## Workaround for existing 9.2.7/9.2.8 debs on airgapped hosts

The shipped binary does not need libreadline8, only the metadata claims it:

```bash
sudo dpkg -i --ignore-depends=libreadline8 aerospike-aql_9.2.8_<distro>_<arch>.deb
```