### PR TITLE
fix(pkg): add -1 release iteration to deb/rpm package names

### DIFF
--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -377,8 +377,8 @@ function generate_bake() {
 #   LOCAL_PKGS_COPIED           (paths to clean up on EXIT)
 # ---------------------------------------------------------------------------
 function resolve_packages() {
-  local pkg_amd64="aerospike-aql_${VERSION}_ubuntu24.04_x86_64.deb"
-  local pkg_arm64="aerospike-aql_${VERSION}_ubuntu24.04_aarch64.deb"
+  local pkg_amd64="aerospike-aql_${VERSION}-1_ubuntu24.04_x86_64.deb"
+  local pkg_arm64="aerospike-aql_${VERSION}-1_ubuntu24.04_aarch64.deb"
   local pool="${DEB_BASE_URL}/pool/${UBUNTU_CODENAME}/aerospike-aql"
 
   AQL_AMD64_URL="${pool}/${pkg_amd64}"

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -18,6 +18,8 @@ URL = "https://github.com/aerospike/$(PACKAGE_NAME)"
 VENDOR = "Aerospike, Inc."
 ARCH = $(shell uname -m)
 RPM_VERSION := $(subst -,_,$(VERSION))
+# rpm Release / deb revision: the "-1" after the version in package names.
+ITERATION ?= 1
 # pkgbuild rejects '-' and '_' in --version; normalize pre-release tags to '.' (see CI .pkg rename).
 MAC_VERSION := $(subst _,.,$(subst -,.,$(VERSION)))
 MAC_ROOT = $(BUILD_DIR)/mac-root
@@ -37,6 +39,7 @@ deb: prep
 		--chdir $(BUILD_DIR)/ \
 		--name $(NAME) \
 		--version $(VERSION) \
+		--iteration $(ITERATION) \
 		--maintainer $(MAINTAINER) \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \
@@ -44,7 +47,7 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--package $(TARGET_DIR)/$(NAME)_$(VERSION)_$(BUILD_DISTRO)_$(ARCH).deb
+		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(ITERATION)_$(BUILD_DISTRO)_$(ARCH).deb
 
 .PHONY: rpm
 rpm: prep
@@ -55,6 +58,7 @@ rpm: prep
 		--chdir $(BUILD_DIR)/ \
 		--name $(NAME) \
 		--version $(RPM_VERSION) \
+		--iteration $(ITERATION) \
 		--maintainer $(MAINTAINER) \
 		--depends "openssl-libs" \
 		--depends "ncurses-libs" \
@@ -64,7 +68,7 @@ rpm: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION).$(BUILD_DISTRO).$(ARCH).rpm
+		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar
 tar: prep


### PR DESCRIPTION
## What

Adds a package release iteration (`-1`) after the version in .deb/.rpm artifact names, matching the server convention (`aerospike-server-community-8.1.3.0-66.amzn2023.aarch64.rpm`).

| Artifact | Before | After |
|---|---|---|
| rpm | `aerospike-aql-9.2.9.el8.x86_64.rpm` | `aerospike-aql-9.2.9-1.el8.x86_64.rpm` |
| deb | `aerospike-aql_9.2.9_ubuntu24.04_x86_64.deb` | `aerospike-aql_9.2.9-1_ubuntu24.04_x86_64.deb` |

## How

- `pkg/Makefile`: new `ITERATION ?= 1`, passed to fpm as `--iteration` and appended in the `--package` filenames.
- rpm: metadata already carried `Release: 1` (fpm default), so only the filename changes.
- deb: control `Version` becomes `9.2.9-1` (proper Debian revision, sorts above the bare `9.2.9`).
- `docker/docker-build.sh`: the released deb it resolves by name gains the `-1`.
- tar and macOS .pkg names are unchanged (no revision concept there).

## Verification

- `make -n` dry runs expand to `aerospike-aql_X.Y.Z-1_<distro>_<arch>.deb` and `aerospike-aql-X.Y.Z-1.<distro>.<arch>.rpm`; rc versions expand to `X.Y.Z-rc1-1` (deb) / `X.Y.Z_rc1-1` (rpm).
- CI test-install globs (`*_<distro>_*<arch>*.deb`, `*.<distro>.*<arch>*.rpm`) already match the new names, no workflow change needed.

## Coordination

The aerospike-tools bundle downloads per-tool packages from JFrog by name; its companion PR updates those globs with a fallback so bundle builds work with tool versions released before or after this change. Bundle picks up the new names once a release is cut from this branch's repo.
