### PR TITLE
fix(pkg): embed distro in deb revision per Debian convention

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -431,7 +431,7 @@ jobs:
           case "${{ matrix.distro }}" in
             ubuntu*|debian*)
               export DEBIAN_FRONTEND=noninteractive
-              pkg=$(find ./packages -name "*_${{ matrix.distro }}_*${arch}*.deb" | head -1)
+              pkg=$(find ./packages -name "*${{ matrix.distro }}_*${arch}*.deb" | head -1)
               [[ -n "${pkg}" ]] || { echo "ERROR: no .deb found for ${{ matrix.distro }}/${arch}" >&2; exit 1; }
               apt-get install -y "${pkg}"
               echo "ASTOOLS_REINSTALL=dpkg -i ${pkg}" >> "$GITHUB_ENV"

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -377,8 +377,8 @@ function generate_bake() {
 #   LOCAL_PKGS_COPIED           (paths to clean up on EXIT)
 # ---------------------------------------------------------------------------
 function resolve_packages() {
-  local pkg_amd64="aerospike-aql_${VERSION}-1_ubuntu24.04_x86_64.deb"
-  local pkg_arm64="aerospike-aql_${VERSION}-1_ubuntu24.04_aarch64.deb"
+  local pkg_amd64="aerospike-aql_${VERSION}-1ubuntu24.04_x86_64.deb"
+  local pkg_arm64="aerospike-aql_${VERSION}-1ubuntu24.04_aarch64.deb"
   local pool="${DEB_BASE_URL}/pool/${UBUNTU_CODENAME}/aerospike-aql"
 
   AQL_AMD64_URL="${pool}/${pkg_amd64}"

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -18,8 +18,10 @@ URL = "https://github.com/aerospike/$(PACKAGE_NAME)"
 VENDOR = "Aerospike, Inc."
 ARCH = $(shell uname -m)
 RPM_VERSION := $(subst -,_,$(VERSION))
-# rpm Release / deb revision: the "-1" after the version in package names.
+# rpm Release / deb revision. The deb revision embeds the distro per Debian
+# convention (e.g. 5.0.3-1debian12), like the rpm dist tag.
 ITERATION ?= 1
+DEB_ITERATION = $(ITERATION)$(BUILD_DISTRO)
 # pkgbuild rejects '-' and '_' in --version; normalize pre-release tags to '.' (see CI .pkg rename).
 MAC_VERSION := $(subst _,.,$(subst -,.,$(VERSION)))
 MAC_ROOT = $(BUILD_DIR)/mac-root
@@ -39,7 +41,7 @@ deb: prep
 		--chdir $(BUILD_DIR)/ \
 		--name $(NAME) \
 		--version $(VERSION) \
-		--iteration $(ITERATION) \
+		--iteration $(DEB_ITERATION) \
 		--maintainer $(MAINTAINER) \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \
@@ -47,7 +49,7 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(ITERATION)_$(BUILD_DISTRO)_$(ARCH).deb
+		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
 .PHONY: rpm
 rpm: prep


### PR DESCRIPTION
## What

Moves the distro into the deb **revision**, per Debian convention and matching server packages (`aerospike-server-community_8.1.3.0-66debian13_arm64.deb`). Follow-up to the earlier `-1` iteration change.

| | Filename |
|---|---|
| Before | `aerospike-aql_9.2.9-1_debian12_x86_64.deb` |
| After | `aerospike-aql_9.2.9-1debian12_x86_64.deb` |

Debian filenames carry exactly three underscore-separated fields (`name_version_arch`); vendors encode the distro inside the revision (`-0ubuntu0.24.04.1`, `.pgdg120+1`, `~bpo11+1`, server's `-66debian13`).

## How

- `pkg/Makefile`: `DEB_ITERATION = $(ITERATION)$(BUILD_DISTRO)`; deb fpm gets `--iteration 1<distro>`, so control `Version` is e.g. `9.2.9-1debian12` and per-distro builds carry distinct Versions.
- rpm unchanged: dist tag already sits in the Release position (`-1.el9`), which is the rpm equivalent.
- CI test-install deb glob and `docker/docker-build.sh` updated; the relaxed glob (`*<distro>_*`) matches both new and previous layouts.
- JFrog upload side verified: shared-workflows `get_codename_for_deb` substring-matches the distro anywhere in the filename, so pool/codename mapping is unaffected.

## Verification

`make -n` dry runs: `aerospike-aql_9.9.9-1ubuntu24.04_x86_64.deb`; rc case `9.9.9-rc1-1debian12` parses as upstream `9.9.9-rc1` + revision `1debian12` under dpkg's last-hyphen rule.

## Coordination

Bundle PR citrusleaf/aerospike-tools#436 already fetches with distro-agnostic globs covering both layouts.
