### PR TITLE
fix(pkg): declare file ownership against the aerospike-tools bundle

### DIFF
--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -32,6 +32,10 @@ MAC_PKG = $(TARGET_DIR)/aerospike-aql-$(MAC_VERSION)-$(ARCH).pkg
 .PHONY: all
 all: deb rpm tar
 
+# The aerospike-tools bundle ships these same /opt/aerospike/bin paths. deb
+# Replaces (without Conflicts) lets dpkg hand file ownership to this package;
+# rpm has no equivalent, so Conflicts turns an opaque file-conflict error into
+# an actionable one.
 .PHONY: deb
 deb: prep
 	fpm --force \
@@ -49,6 +53,7 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
+		--replaces "aerospike-tools" \
 		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
 .PHONY: rpm
@@ -70,6 +75,7 @@ rpm: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
+		--conflicts "aerospike-tools" \
 		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar


### PR DESCRIPTION
## Problem

Installing this package on a host that already has the `aerospike-tools` bundle fails:

```
dpkg: error processing archive aerospike-asbackup_4.5.8-1ubuntu22.04_aarch64.deb (--install):
 trying to overwrite '/opt/aerospike/bin/asrestore', which is also in package aerospike-tools 13.0.3+rc1+1+g7d9b9d770
```

The bundle is assembled by extracting the standalone tool packages into one tree, so it physically ships the same `/opt/aerospike/bin` paths. Neither side declared a relationship, so dpkg/rpm refuse the overwrite.

## Change

| target | flag | effect |
|---|---|---|
| deb | `--replaces "aerospike-tools"` | dpkg transfers ownership of the overlapping paths to this package; the bundle stays installed. Removing the bundle later no longer deletes binaries this package owns. |
| rpm | `--conflicts "aerospike-tools"` | rpm has no `Replaces` for a partial takeover. `Conflicts` turns the opaque file-conflict error into an actionable one. |

No `Conflicts` on deb, deliberately: with `Conflicts`, plain `dpkg -i` hard-fails instead of resolving. `Replaces` alone is the standard handling for files moving between packages.

Unversioned on purpose. The bundle keeps shipping these paths, so the overlap covers every bundle version, not only the ones released so far. A version bound would break again the moment the bundle is rebuilt above the bound.

## Upgrade matrix after this change

| from | to | deb | rpm | macOS |
|---|---|---|---|---|
| bundle | standalone | works | clear conflict, `dnf remove aerospike-tools` first | works |
| standalone | standalone | works | works | works |
| standalone | bundle | works (bundle-side PR) | clear conflict | works |
| bundle | bundle | works | works | works |

## Known gap

rpm cannot do a partial file takeover, so bundle ↔ standalone stays a manual removal on RHEL/EL. The permanent fix is converting `aerospike-tools` into a metapackage that ships only `astools.conf` and depends on the standalone packages, which removes the path overlap entirely on both formats. Tracked separately.

## Testing

- `Replaces:` / `Conflicts:` field emission verified against the fpm templates; actual control-field assertions happen in the Linux CI package build.
- Needs a manual pass on a host with the bundle installed: `dpkg -i` the new package and confirm it installs clean, then `apt remove aerospike-tools` and confirm the binaries survive.
